### PR TITLE
Missing language features

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -66,6 +66,7 @@ class ElectrumLexer(RegexLexer):
             (iden_rex, Name.Class),
             text_tuple,
             (r',', Punctuation),
+            (r'\+', Punctuation),
             (r'\{', Operator, '#pop'),
         ],
         'module': [
@@ -80,7 +81,8 @@ class ElectrumLexer(RegexLexer):
         'root': [
             (r'--.*?$', Comment.Single),
             (r'//.*?$', Comment.Single),
-            (r'/\*.*?\*/', Comment.Multiline),
+            (r'/\*(.|\n)*?\*/', Comment.Multiline),
+            (r'{-(.|\n)*?-}', Comment.Multiline),
             text_tuple,
             (r'(module|open)(\s+)', bygroups(Keyword.Namespace, Text), 'module'),
             (r'(sig|enum)(\s+)', bygroups(Keyword.Declaration, Text), 'sig'),
@@ -89,7 +91,7 @@ class ElectrumLexer(RegexLexer):
             (r'(this|abstract|extends|set|seq|one|lone|let)\b', Keyword),
             (r'(all|some|no|sum|disj|when|else)\b', Keyword),
             (r'(var)\b', Keyword),
-            (r'(run|check|for|but|exactly|steps)\b', Keyword),
+            (r'(run|check|for|but|exactly|steps|expect)\b', Keyword),
             (r'(not|and|or|implies|iff|in)\b', Operator.Word),
             (r'(always|eventually|after|until|releases)\b', Operator.Word),
             (r'(historically|once|before|since|triggered)\b', Operator.Word),

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -56,7 +56,7 @@ class ElectrumLexer(RegexLexer):
     aliases = ['electrum']
     filenames = ['*.als','.ele']
 
-    iden_rex = r'[a-zA-Z_][a-zA-Z0-9_]*'
+    iden_rex = r'[a-zA-Z_][a-zA-Z0-9_]*\$?'
     text_tuple = (r'[^\S\n]+', Text)
 
     tokens = {

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -62,6 +62,7 @@ class ElectrumLexer(RegexLexer):
     tokens = {
         'sig': [
             (r'(extends)\b', Keyword),
+            (r'(=)', Keyword),
             (r'(in)\b', Keyword),
             (iden_rex, Name.Class),
             text_tuple,


### PR DESCRIPTION
Adds missing Alloy features:
- multiline comments
- `expect` keyword on commands
- signature declaration through equality `=`
- meta-identifiers ending in `$`